### PR TITLE
Highlight native Vite 8 support on homepage

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -2,7 +2,7 @@ export default defineAppConfig({
   shadcnDocs: {
     site: {
       name: 'CRXJS',
-      description: 'Build cross-browser extensions with native HMR and zero-config setup',
+      description: 'Build cross-browser extensions with native HMR, zero-config setup, and Vite 8 support',
       umami: {
         enable: true,
         src: 'https://crxjs.dev/',

--- a/content/index.md
+++ b/content/index.md
@@ -1,15 +1,15 @@
 ---
 title: CRXJS
 navigation: false
-description: Build cross-browser extensions with native HMR and zero-config setup
+description: Build cross-browser extensions with native HMR, zero-config setup, and Vite 8 support
 ---
 
 ::hero-section
 ---
 announcement:
-  title: v2.0 release
-  icon: i-mdi:package-variant-closed
-  to: https://github.com/crxjs/chrome-extension-tools/discussions/1020
+  title: Native Vite 8 support
+  icon: i-mdi:lightning-bolt
+  to: https://github.com/crxjs/chrome-extension-tools/releases/tag/vite-plugin-v2.6.1
   target: _blank
 ---
 ::

--- a/content/zh/index.md
+++ b/content/zh/index.md
@@ -1,15 +1,15 @@
 ---
 title: CRXJS
 navigation: false
-description: 现代化跨浏览器扩展开发：原生 HMR 与开箱即用的零配置
+description: 现代化跨浏览器扩展开发：原生 HMR、开箱即用的零配置与 Vite 8 支持
 ---
 
 ::hero-section
 ---
 announcement:
-  title: v2.0 release
-  icon: i-mdi:package-variant-closed
-  to: https://github.com/crxjs/chrome-extension-tools/discussions/1020
+  title: 原生支持 Vite 8
+  icon: i-mdi:lightning-bolt
+  to: https://github.com/crxjs/chrome-extension-tools/releases/tag/vite-plugin-v2.6.1
   target: _blank
 ---
 ::

--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -3,7 +3,7 @@ export default defineI18nConfig(() => ({
   locale: 'en',
   messages: {
     en: {
-      'description': 'Build cross-browser extensions with native HMR and zero-config setup',
+      'description': 'Build cross-browser extensions with native HMR, zero-config setup, and Vite 8 support',
       'getStarted': 'Get Started',
       'copiedToClipboard': 'Copied "{text}" to clipboard',
       'Edit this page': 'Edit this page',
@@ -22,7 +22,7 @@ export default defineI18nConfig(() => ({
       'Contribute your CRXJS project': 'Contribute Your CRXJS Project',
     },
     zh: {
-      'description': '现代化跨浏览器扩展开发：原生 HMR 与开箱即用的零配置',
+      'description': '现代化跨浏览器扩展开发：原生 HMR、开箱即用的零配置与 Vite 8 支持',
       'getStarted': '开始使用',
       'copiedToClipboard': '已复制 "{text}" 到剪贴板',
       'Edit this page': '编辑此页面',

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -18,7 +18,7 @@ export default defineNuxtConfig({
   site: {
     url: 'https://crxjs.dev/',
     title: 'CRXJS',
-    description: 'Build cross-browser extensions with native HMR and zero-config setup',
+    description: 'Build cross-browser extensions with native HMR, zero-config setup, and Vite 8 support',
   },
 
   mdc: {
@@ -60,10 +60,10 @@ export default defineNuxtConfig({
   llms: {
     domain: 'https://crxjs.dev/',
     title: 'CRXJS Documentation',
-    description: 'Build cross-browser extensions with native HMR and zero-config setup.',
+    description: 'Build cross-browser extensions with native HMR, zero-config setup, and Vite 8 support.',
     full: {
       title: 'CRXJS Documentation',
-      description: 'Build cross-browser extensions with native HMR and zero-config setup.',
+      description: 'Build cross-browser extensions with native HMR, zero-config setup, and Vite 8 support.',
     },
     sections: [
       {


### PR DESCRIPTION
## Summary

- Update the homepage announcement to highlight native Vite 8 support.
- Point the announcement link at the @crxjs/vite-plugin v2.6.1 release notes.
- Refresh English and Chinese homepage descriptions plus site metadata to mention Vite 8 support.

## Validation

- pnpm build
- Local render smoke check for `/` and `/zh/` confirmed the announcement text and release URL in HTML.
- pnpm lint currently fails on existing style issues in `components/content/Tabs.vue`, `components/content/TabsInner.vue`, and `components/ui/SparklesText.vue`.
