### PR TITLE
docs: clarify content script HMR support

### DIFF
--- a/content/1.guide/1.introduction.md
+++ b/content/1.guide/1.introduction.md
@@ -4,7 +4,7 @@ description: CRXJS provides a smooth hot-reload browser extension development ex
 icon: 'lucide:info'
 ---
 
-CRXJS is committed to providing developers with an efficient, modern browser extension development experience. By directly parsing the manifest.json file, it enables a zero-configuration development workflow and supports global Hot Module Replacement (HMR) including content scripts.
+CRXJS is committed to providing developers with an efficient, modern browser extension development experience. By directly parsing the manifest.json file, it enables a zero-configuration development workflow and supports global Hot Module Replacement (HMR), including content scripts in both the isolated world and main world since [@crxjs/vite-plugin v2.7.0](https://github.com/crxjs/chrome-extension-tools/releases/tag/vite-plugin-v2.7.0).
 CRXJS is compatible with major frontend frameworks and suitable for various technology stacks, helping developers focus on feature implementation without worrying about tedious build and configuration details.
 
 ## Background and Motivation
@@ -21,7 +21,7 @@ CRXJS provides a unified, concise and efficient solution to the above problems.
 
 - **Hot Module Replacement (HMR)**
 
-Supports global hot updates including content scripts and page scripts. During development, code changes can be reflected immediately without manual refresh or extension reload, significantly improving development efficiency.
+Supports global hot updates for page scripts and for content scripts in both the isolated world and main world since [@crxjs/vite-plugin v2.7.0](https://github.com/crxjs/chrome-extension-tools/releases/tag/vite-plugin-v2.7.0). During development, code changes can be reflected immediately without manual refresh or extension reload, significantly improving development efficiency.
 
 - **Zero Configuration Development**
 

--- a/content/2.concepts/4.content.md
+++ b/content/2.concepts/4.content.md
@@ -1,8 +1,10 @@
 ---
 title: Content Scripts
-description: CRXJS provides content scripts with Vite HMR.
+description: CRXJS provides Vite HMR for isolated and main world content scripts since v2.7.0.
 icon: 'lucide:code-xml'
 ---
+
+Since [@crxjs/vite-plugin v2.7.0](https://github.com/crxjs/chrome-extension-tools/releases/tag/vite-plugin-v2.7.0), content script HMR works in both Chrome's isolated world and main world.
 
 ## Static Assets
 

--- a/content/zh/1.guide/1.introduction.md
+++ b/content/zh/1.guide/1.introduction.md
@@ -7,7 +7,7 @@ icon: 'lucide:info'
 
 
 
-CRXJS 致力于为开发者提供高效、现代化的浏览器扩展开发体验。它通过直接解析 manifest.json 文件，实现了零配置的开发流程，并支持包括内容脚本在内的全局热模块替换（HMR）。
+CRXJS 致力于为开发者提供高效、现代化的浏览器扩展开发体验。它通过直接解析 manifest.json 文件，实现了零配置的开发流程，并支持包括内容脚本在内的全局热模块替换（HMR）；从 [@crxjs/vite-plugin v2.7.0](https://github.com/crxjs/chrome-extension-tools/releases/tag/vite-plugin-v2.7.0) 起，内容脚本 HMR 同时支持隔离世界（isolated world）和主世界（main world）。
 CRXJS 兼容主流前端框架，适用于多种技术栈，帮助开发者专注于功能实现，而无需关注繁琐的构建和配置细节。
 
 ## 背景与动机
@@ -24,7 +24,7 @@ CRXJS 针对上述问题，提供了统一、简洁且高效的解决方案。
 
 - **热模块替换（HMR）**
 
-支持包括内容脚本、页面脚本在内的全局热更新。开发过程中，代码变更可即时反映，无需手动刷新或重载扩展，显著提升开发效率。
+支持页面脚本，以及从 [@crxjs/vite-plugin v2.7.0](https://github.com/crxjs/chrome-extension-tools/releases/tag/vite-plugin-v2.7.0) 起同时运行在隔离世界（isolated world）和主世界（main world）的内容脚本的全局热更新。开发过程中，代码变更可即时反映，无需手动刷新或重载扩展，显著提升开发效率。
 
 - **零配置开发**
 

--- a/content/zh/2.concepts/4.content.md
+++ b/content/zh/2.concepts/4.content.md
@@ -1,8 +1,10 @@
 ---
 title: 内容脚本（Content Scripts）
-description: CRXJS为内容脚本提供Vite HMR。
+description: CRXJS 从 v2.7.0 起为隔离世界和主世界内容脚本提供 Vite HMR。
 icon: 'lucide:code-xml'
 ---
+
+从 [@crxjs/vite-plugin v2.7.0](https://github.com/crxjs/chrome-extension-tools/releases/tag/vite-plugin-v2.7.0) 起，内容脚本 HMR 同时支持 Chrome 的隔离世界（isolated world）和主世界（main world）。
 
 ## 静态资源
 


### PR DESCRIPTION
## Summary
- Update English docs to clarify that content script HMR supports both isolated world and main world.
- Update matching Chinese docs and content page descriptions.
- Link the support note to the @crxjs/vite-plugin v2.7.0 release.

## Validation
- pnpm build
- git diff --check