### PR TITLE
docs: explain IIFE content scripts

### DIFF
--- a/content/2.concepts/4.content.md
+++ b/content/2.concepts/4.content.md
@@ -21,72 +21,84 @@ const url = chrome.runtime.getURL(logo)
 
 ## IIFE content scripts
 
-CRXJS normally uses a loader for content scripts so Vite can provide HMR during
-development and support regular ESM imports. The loader runs asynchronously.
-For most content scripts this is fine, but it can be too late for scripts that
-must patch host page APIs before page scripts run.
+CRXJS normally runs content scripts through an async loader. That loader enables
+Vite HMR and regular ESM imports, but it can be too late for `document_start`
+scripts that must patch host page APIs before page code runs.
 
-Use an IIFE content script when you need exact `document_start` timing, for
-example to intercept `fetch`, `XMLHttpRequest`, DOM events, or globals before
-the host page reads them. IIFE content scripts are bundled as standalone files,
-so their imports are inlined and Chrome runs the emitted file directly.
+Use an IIFE content script for timing-sensitive work like intercepting `fetch`,
+`XMLHttpRequest`, DOM events, or globals in the main world. CRXJS emits the
+script as a standalone bundle with its imports inlined, and Chrome runs that
+file directly.
 
-The recommended way to opt in is the filename convention:
+::alert{type="warning" icon="lucide:triangle-alert"}
+IIFE content scripts do not receive in-place Vite HMR. During development CRXJS
+rebuilds the standalone file, but the updated script only runs after the host
+page reloads or navigates again.
+::
 
-```ts [manifest.config.ts]
-import { defineManifest } from '@crxjs/vite-plugin'
+### Enable IIFE output
 
-export default defineManifest({
-  manifest_version: 3,
-  name: 'My Extension',
-  version: '1.0.0',
-  content_scripts: [{
-    js: ['src/content/interceptor.iife.ts'],
+::tabs
+  ::div{label="File name" icon="lucide:file-code"}
+  Add `.iife` before the source extension. This works for
+  `.iife.ts`, `.iife.tsx`, `.iife.js`, and `.iife.jsx`.
+
+  ```ts [manifest.config.ts]
+  import { defineManifest } from '@crxjs/vite-plugin'
+
+  export default defineManifest({
+    manifest_version: 3,
+    name: 'My Extension',
+    version: '1.0.0',
+    content_scripts: [{
+      js: ['src/content/interceptor.iife.ts'],
+      matches: ['https://example.com/*'],
+      run_at: 'document_start',
+      world: 'MAIN',
+    }],
+  })
+  ```
+  ::
+
+  ::div{label="standaloneFiles" icon="lucide:file-plus-2"}
+  If you cannot rename the file, list it in `contentScripts.standaloneFiles`.
+
+  ```ts [vite.config.ts]
+  import { crx } from '@crxjs/vite-plugin'
+  import { defineConfig } from 'vite'
+  import manifest from './manifest.config'
+
+  export default defineConfig({
+    plugins: [
+      crx({
+        manifest,
+        contentScripts: {
+          standaloneFiles: ['src/content/interceptor.ts'],
+        },
+      }),
+    ],
+  })
+  ```
+  ::
+
+  ::div{label="Dynamic" icon="lucide:zap"}
+  For scripts registered with `chrome.scripting`, import the generated file path
+  with either `?iife` or the `.iife` filename convention plus `?script`.
+
+  ```ts [background.ts]
+  import interceptor from './content/interceptor.ts?iife'
+  // import interceptor from './content/interceptor.iife.ts?script'
+
+  chrome.scripting.registerContentScripts([{
+    id: 'network-interceptor',
+    js: [interceptor],
     matches: ['https://example.com/*'],
-    run_at: 'document_start',
+    runAt: 'document_start',
     world: 'MAIN',
-  }],
-})
-```
-
-You can use `.iife.ts`, `.iife.tsx`, `.iife.js`, or `.iife.jsx`. If you cannot
-rename the file, list it in `contentScripts.standaloneFiles`.
-
-```ts [vite.config.ts]
-import { crx } from '@crxjs/vite-plugin'
-import { defineConfig } from 'vite'
-import manifest from './manifest.config'
-
-export default defineConfig({
-  plugins: [
-    crx({
-      manifest,
-      contentScripts: {
-        standaloneFiles: ['src/content/interceptor.ts'],
-      },
-    }),
-  ],
-})
-```
-
-For dynamically registered content scripts, import the file with `?iife` or use
-the `.iife` filename convention with `?script`.
-
-```ts [background.ts]
-import interceptor from './content/interceptor.iife.ts?script'
-
-chrome.scripting.registerContentScripts([{
-  id: 'network-interceptor',
-  js: [interceptor],
-  matches: ['https://example.com/*'],
-  runAt: 'document_start',
-  world: 'MAIN',
-}])
-```
-
-IIFE content scripts do not get in-place Vite HMR. In development, CRXJS rebuilds
-the standalone file and the updated script runs after the host page is reloaded
-or navigated again.
+  }])
+  ```
+  ::
+::
 
 ## HTML in content scripts
 

--- a/content/2.concepts/4.content.md
+++ b/content/2.concepts/4.content.md
@@ -36,6 +36,18 @@ rebuilds the standalone file, but the updated script only runs after the host
 page reloads or navigates again.
 ::
 
+### Recommended architecture
+
+Keep most of your extension logic in the default isolated world content script.
+It stays separated from page JavaScript, can use the extension APIs available to
+content scripts, and receives full Vite HMR in development.
+
+Use a `MAIN` world IIFE only for the part that must run inside the host page
+environment. Treat it as a small bridge: install the early hook at
+`document_start`, then pass commands or data to the isolated content script with
+`window.postMessage`, `CustomEvent`, or DOM events. This keeps the non-HMR script
+small and stable.
+
 ### Enable IIFE output
 
 ::tabs

--- a/content/2.concepts/4.content.md
+++ b/content/2.concepts/4.content.md
@@ -19,6 +19,75 @@ import logo from './logo.png'
 const url = chrome.runtime.getURL(logo)
 ```
 
+## IIFE content scripts
+
+CRXJS normally uses a loader for content scripts so Vite can provide HMR during
+development and support regular ESM imports. The loader runs asynchronously.
+For most content scripts this is fine, but it can be too late for scripts that
+must patch host page APIs before page scripts run.
+
+Use an IIFE content script when you need exact `document_start` timing, for
+example to intercept `fetch`, `XMLHttpRequest`, DOM events, or globals before
+the host page reads them. IIFE content scripts are bundled as standalone files,
+so their imports are inlined and Chrome runs the emitted file directly.
+
+The recommended way to opt in is the filename convention:
+
+```ts [manifest.config.ts]
+import { defineManifest } from '@crxjs/vite-plugin'
+
+export default defineManifest({
+  manifest_version: 3,
+  name: 'My Extension',
+  version: '1.0.0',
+  content_scripts: [{
+    js: ['src/content/interceptor.iife.ts'],
+    matches: ['https://example.com/*'],
+    run_at: 'document_start',
+    world: 'MAIN',
+  }],
+})
+```
+
+You can use `.iife.ts`, `.iife.tsx`, `.iife.js`, or `.iife.jsx`. If you cannot
+rename the file, list it in `contentScripts.standaloneFiles`.
+
+```ts [vite.config.ts]
+import { crx } from '@crxjs/vite-plugin'
+import { defineConfig } from 'vite'
+import manifest from './manifest.config'
+
+export default defineConfig({
+  plugins: [
+    crx({
+      manifest,
+      contentScripts: {
+        standaloneFiles: ['src/content/interceptor.ts'],
+      },
+    }),
+  ],
+})
+```
+
+For dynamically registered content scripts, import the file with `?iife` or use
+the `.iife` filename convention with `?script`.
+
+```ts [background.ts]
+import interceptor from './content/interceptor.iife.ts?script'
+
+chrome.scripting.registerContentScripts([{
+  id: 'network-interceptor',
+  js: [interceptor],
+  matches: ['https://example.com/*'],
+  runAt: 'document_start',
+  world: 'MAIN',
+}])
+```
+
+IIFE content scripts do not get in-place Vite HMR. In development, CRXJS rebuilds
+the standalone file and the updated script runs after the host page is reloaded
+or navigated again.
+
 ## HTML in content scripts
 
 It is possible to inject an extension page into a host page using an iframe. The

--- a/content/zh/2.concepts/4.content.md
+++ b/content/zh/2.concepts/4.content.md
@@ -32,6 +32,17 @@ IIFE内容脚本不支持就地Vite HMR。开发期间CRXJS会重新构建独立
 但更新后的脚本只会在宿主页面重新加载或再次导航后运行。
 ::
 
+### 推荐架构
+
+请尽量将大部分扩展逻辑放在默认的isolated world内容脚本中。它与页面
+JavaScript隔离，可以使用内容脚本可用的扩展API，并且在开发期间支持完整
+的Vite HMR。
+
+只有必须在宿主页面环境中执行的部分才使用`MAIN` world IIFE。把它当作一个
+小型bridge：在`document_start`安装早期hook，然后通过`window.postMessage`、
+`CustomEvent`或DOM事件把命令或数据传给isolated内容脚本。这样可以让不支持
+HMR的脚本保持小而稳定。
+
 ### 启用IIFE输出
 
 ::tabs

--- a/content/zh/2.concepts/4.content.md
+++ b/content/zh/2.concepts/4.content.md
@@ -17,6 +17,65 @@ import logo from './logo.png'
 const url = chrome.runtime.getURL(logo)
 ```
 
+## IIFE内容脚本
+
+CRXJS通常会为内容脚本使用loader，以便在开发期间提供Vite HMR并支持常规ESM导入。loader是异步执行的。对于大多数内容脚本来说这没有问题，但如果脚本必须在页面脚本运行前修补宿主页面API，这可能太晚。
+
+当您需要精确的`document_start`时机时，请使用IIFE内容脚本。例如在宿主页面读取之前拦截`fetch`、`XMLHttpRequest`、DOM事件或全局变量。IIFE内容脚本会被打包为独立文件，导入会被内联，Chrome会直接运行生成的文件。
+
+推荐的启用方式是文件命名约定：
+
+```ts [manifest.config.ts]
+import { defineManifest } from '@crxjs/vite-plugin'
+
+export default defineManifest({
+  manifest_version: 3,
+  name: 'My Extension',
+  version: '1.0.0',
+  content_scripts: [{
+    js: ['src/content/interceptor.iife.ts'],
+    matches: ['https://example.com/*'],
+    run_at: 'document_start',
+    world: 'MAIN',
+  }],
+})
+```
+
+可以使用`.iife.ts`、`.iife.tsx`、`.iife.js`或`.iife.jsx`。如果不能重命名文件，请在`contentScripts.standaloneFiles`中列出它。
+
+```ts [vite.config.ts]
+import { crx } from '@crxjs/vite-plugin'
+import { defineConfig } from 'vite'
+import manifest from './manifest.config'
+
+export default defineConfig({
+  plugins: [
+    crx({
+      manifest,
+      contentScripts: {
+        standaloneFiles: ['src/content/interceptor.ts'],
+      },
+    }),
+  ],
+})
+```
+
+对于动态注册的内容脚本，请使用`?iife`导入文件，或将`.iife`文件名约定与`?script`一起使用。
+
+```ts [background.ts]
+import interceptor from './content/interceptor.iife.ts?script'
+
+chrome.scripting.registerContentScripts([{
+  id: 'network-interceptor',
+  js: [interceptor],
+  matches: ['https://example.com/*'],
+  runAt: 'document_start',
+  world: 'MAIN',
+}])
+```
+
+IIFE内容脚本不支持就地Vite HMR。在开发期间，CRXJS会重新构建独立文件；重新加载或再次导航宿主页面后，会运行更新后的脚本。
+
 ## 内容脚本中的HTML
 
 可以使用iframe将扩展页面注入到宿主页面中。即使宿主页面指定了`frame-src`策略，宿主页面的CSP也不会影响注入的iframe。

--- a/content/zh/2.concepts/4.content.md
+++ b/content/zh/2.concepts/4.content.md
@@ -19,62 +19,82 @@ const url = chrome.runtime.getURL(logo)
 
 ## IIFE内容脚本
 
-CRXJS通常会为内容脚本使用loader，以便在开发期间提供Vite HMR并支持常规ESM导入。loader是异步执行的。对于大多数内容脚本来说这没有问题，但如果脚本必须在页面脚本运行前修补宿主页面API，这可能太晚。
+CRXJS通常会通过异步loader运行内容脚本。这个loader可以启用Vite HMR
+并支持常规ESM导入，但对于必须在页面代码运行前修补宿主页面API的
+`document_start`脚本来说，它可能太晚。
 
-当您需要精确的`document_start`时机时，请使用IIFE内容脚本。例如在宿主页面读取之前拦截`fetch`、`XMLHttpRequest`、DOM事件或全局变量。IIFE内容脚本会被打包为独立文件，导入会被内联，Chrome会直接运行生成的文件。
+如果需要在main world中拦截`fetch`、`XMLHttpRequest`、DOM事件或全局变量
+等时序敏感逻辑，请使用IIFE内容脚本。CRXJS会将脚本输出为独立bundle，
+并内联它的导入，Chrome会直接运行该文件。
 
-推荐的启用方式是文件命名约定：
+::alert{type="warning" icon="lucide:triangle-alert"}
+IIFE内容脚本不支持就地Vite HMR。开发期间CRXJS会重新构建独立文件，
+但更新后的脚本只会在宿主页面重新加载或再次导航后运行。
+::
 
-```ts [manifest.config.ts]
-import { defineManifest } from '@crxjs/vite-plugin'
+### 启用IIFE输出
 
-export default defineManifest({
-  manifest_version: 3,
-  name: 'My Extension',
-  version: '1.0.0',
-  content_scripts: [{
-    js: ['src/content/interceptor.iife.ts'],
+::tabs
+  ::div{label="文件名" icon="lucide:file-code"}
+  在源文件扩展名前添加`.iife`。支持`.iife.ts`、`.iife.tsx`、`.iife.js`
+  和`.iife.jsx`。
+
+  ```ts [manifest.config.ts]
+  import { defineManifest } from '@crxjs/vite-plugin'
+
+  export default defineManifest({
+    manifest_version: 3,
+    name: 'My Extension',
+    version: '1.0.0',
+    content_scripts: [{
+      js: ['src/content/interceptor.iife.ts'],
+      matches: ['https://example.com/*'],
+      run_at: 'document_start',
+      world: 'MAIN',
+    }],
+  })
+  ```
+  ::
+
+  ::div{label="standaloneFiles" icon="lucide:file-plus-2"}
+  如果不能重命名文件，请在`contentScripts.standaloneFiles`中列出它。
+
+  ```ts [vite.config.ts]
+  import { crx } from '@crxjs/vite-plugin'
+  import { defineConfig } from 'vite'
+  import manifest from './manifest.config'
+
+  export default defineConfig({
+    plugins: [
+      crx({
+        manifest,
+        contentScripts: {
+          standaloneFiles: ['src/content/interceptor.ts'],
+        },
+      }),
+    ],
+  })
+  ```
+  ::
+
+  ::div{label="动态注册" icon="lucide:zap"}
+  对于通过`chrome.scripting`注册的脚本，可以使用`?iife`导入生成的文件路径，
+  或使用`.iife`文件名约定加`?script`。
+
+  ```ts [background.ts]
+  import interceptor from './content/interceptor.ts?iife'
+  // import interceptor from './content/interceptor.iife.ts?script'
+
+  chrome.scripting.registerContentScripts([{
+    id: 'network-interceptor',
+    js: [interceptor],
     matches: ['https://example.com/*'],
-    run_at: 'document_start',
+    runAt: 'document_start',
     world: 'MAIN',
-  }],
-})
-```
-
-可以使用`.iife.ts`、`.iife.tsx`、`.iife.js`或`.iife.jsx`。如果不能重命名文件，请在`contentScripts.standaloneFiles`中列出它。
-
-```ts [vite.config.ts]
-import { crx } from '@crxjs/vite-plugin'
-import { defineConfig } from 'vite'
-import manifest from './manifest.config'
-
-export default defineConfig({
-  plugins: [
-    crx({
-      manifest,
-      contentScripts: {
-        standaloneFiles: ['src/content/interceptor.ts'],
-      },
-    }),
-  ],
-})
-```
-
-对于动态注册的内容脚本，请使用`?iife`导入文件，或将`.iife`文件名约定与`?script`一起使用。
-
-```ts [background.ts]
-import interceptor from './content/interceptor.iife.ts?script'
-
-chrome.scripting.registerContentScripts([{
-  id: 'network-interceptor',
-  js: [interceptor],
-  matches: ['https://example.com/*'],
-  runAt: 'document_start',
-  world: 'MAIN',
-}])
-```
-
-IIFE内容脚本不支持就地Vite HMR。在开发期间，CRXJS会重新构建独立文件；重新加载或再次导航宿主页面后，会运行更新后的脚本。
+  }])
+  ```
+  ::
+::
 
 ## 内容脚本中的HTML
 


### PR DESCRIPTION
## Dependency
- Depends on crxjs/chrome-extension-tools#1185. Please merge this docs PR after the plugin change lands.

## Summary
- document IIFE content scripts on the Content Scripts concepts page
- cover .iife filename convention, standaloneFiles, and dynamic ?iife/?script usage
- note that IIFE scripts rebuild in dev but run after page reload/navigation
- add the same section to the zh content page

## Verification
- pnpm build
- pnpm lint fails on existing unrelated Vue component style errors in Tabs.vue, TabsInner.vue, and SparklesText.vue
